### PR TITLE
Subtle improvements to header buttons

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -14,12 +14,18 @@ input {
   display: inline;
 }
 
-h2 {
+h2, .patreon-link {
   border-radius: 8px 8px 0 0;
   background-color: #525276;
   margin: 0 16px 0 0;
   padding: 8px 16px;
   font-size: 20px;
+  cursor: pointer;
+  transition: background-color 200ms linear;
+}
+
+h2.inactive:hover {
+  background-color: #3a3a59;
 }
 
 h3 {
@@ -177,10 +183,12 @@ footer {
 
 .patreon-link {
   background-color: #a33211;
+  text-decoration: none;
+  font-weight: 700;
 }
 
-.patreon-link a {
-  text-decoration: none;
+.patreon-link:hover {
+  background-color: #be340b;
 }
 
 .main-nav {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -217,9 +217,12 @@ function App() {
                   {showCompleted ? "Hide completed" : "Show completed"}
                 </h2>
 
-                <h2 className="patreon-link">
-                  <a href="https://www.patreon.com/Vedgy">Patreon</a>
-                </h2>
+                <a
+                  className="patreon-link"
+                  href="https://www.patreon.com/Vedgy"
+                >
+                  Patreon
+                </a>
               </div>
             </nav>
             <hr />


### PR DESCRIPTION
- Set `cursor: pointer;` on header buttons
- Entire 'Patreon' button is now a link, not just a small inner portion of the button
- Add a subtle transition and hover color to `.inactive` buttons

There was no rhyme or reason to the chosen colors, just thought they looked 'good enough'. Feel free to change them how you like 🙂

![chrome_xrHizYaQny](https://user-images.githubusercontent.com/22661350/176973019-05771617-4a5d-4087-8645-3d24d918087f.gif)

![image](https://user-images.githubusercontent.com/22661350/176973074-1223829e-605d-4c64-9560-1947e08b5db8.png)
![chrome_pDYuQ3oOjg](https://user-images.githubusercontent.com/22661350/176973100-b6a0a09e-5042-4e33-a189-2cdf54a2f740.gif)

