### PR TITLE
Corrected Safe Pockets 3

### DIFF
--- a/src/data.tsx
+++ b/src/data.tsx
@@ -4054,7 +4054,7 @@ export const upgrades: Upgrade[] = [
               },
               {
                 item: "Resin Gun",
-                quantity: 8,
+                quantity: 12,
               },
               {
                 item: "Korolev Scrip",


### PR DESCRIPTION
Corrected Safe Pockets 3 data values

- Changed resin guns required from 8 to 12